### PR TITLE
[FEATURE] disabling readonly arguments.

### DIFF
--- a/typescript/base.js
+++ b/typescript/base.js
@@ -108,10 +108,6 @@ module.exports = {
         ],
         "@typescript-eslint/prefer-optional-chain": "warn",
         "@typescript-eslint/prefer-readonly": "warn",
-        "@typescript-eslint/prefer-readonly-parameter-types": [
-          "warn",
-          {"ignoreInferredTypes": true}
-        ],
         "@typescript-eslint/prefer-reduce-type-parameter": "warn",
         "@typescript-eslint/prefer-return-this-type": "warn",
         "@typescript-eslint/prefer-string-starts-ends-with": "warn",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libra-foundation/eslint-config-typescript",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Grouped configs we use for typescript",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## 1) Description

Disabling the rule `prefer-readonly-parameter-types`.
Closes #4 

## 2) Technical choice

I decided to disable the rule instead of softening it because after having tried the softened version I still keep disabling the rule.
See #4 for more detail on this choice.

## 3) Checks

- [X] My code follows the contributing guidelines
- [X] I have read the code of conduct
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes