### PR TITLE
[FEATURE] `class-methods-use-this`

### DIFF
--- a/typescript/base.js
+++ b/typescript/base.js
@@ -10,7 +10,7 @@ module.exports = {
         "sourceType": "module",
         "project": "./tsconfig.json"
     },
-    "rules": {
+      "rules": {
         "eslint-comments/require-description": [
           "error",
           {"ignore": ["eslint-enable"]}
@@ -50,6 +50,10 @@ module.exports = {
           }
         ],
         "@typescript-eslint/class-literal-property-style": "warn",
+        
+        "class-methods-use-this": "off",
+        "@typescript-eslint/class-methods-use-this": "error",
+
         "@typescript-eslint/consistent-generic-constructors": "warn",
         "@typescript-eslint/consistent-indexed-object-style": "warn",
         "@typescript-eslint/consistent-type-assertions": "warn",


### PR DESCRIPTION
## 1) Description

Disabled the base ESLint `class-methods-use-this` rule in favor of the typescript ESLint one on the TS config.

## 2) Technical choice

The typescript rule is aware of some edge cases like when overriding classes or implementing interfaces, while the plain ESLint isn't. This should reduce famse positives.

## 3) Checks

- [X] My code follows the contributing guidelines
- [X] I have read the code of conduct
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes